### PR TITLE
Update wanderer-conf.env

### DIFF
--- a/wanderer-conf.env
+++ b/wanderer-conf.env
@@ -1,4 +1,4 @@
-BASE_URL=replace-me
+WEB_APP_URL=replace-me
 SECRET_KEY_BASE=replace-me
 CLOAK_KEY=replace-me
 EVE_CLIENT_ID=replace-me


### PR DESCRIPTION
Using BASE_URL and not replacing it with WEB_APP_URL caused socket errors.
> wanderer-1     | 13:55:52.060 application=phoenix module=Phoenix.Socket.Transport function=check_origin/5 line=344 [error] Could not check origin for Phoenix.Socket transport