### PR TITLE
Un-expose wanderer-kills service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,6 @@ services:
     networks:
       wanderer-internal:
       web:
-    ports:
-      - "4004:4004"
     restart: unless-stopped
 
   wanderer_db:


### PR DESCRIPTION
We do not need it exposed to the web, wanderer-service can already access it internally.